### PR TITLE
fix: truncate table cells by visible width and keep ANSI balanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - CLI: support `markdansi file.md` positional input files (#3, thanks @risenowrise).
+- Fix table truncation for styled, linked, CJK, and emoji cells without leaking ANSI/OSC state (#4, thanks @devYRPauli).
 
 ## 0.2.1 (2026-01-10)
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "micromark": "^4.0.2",
     "micromark-extension-gfm": "^3.0.0",
     "micromark-util-combine-extensions": "^2.0.1",
+    "slice-ansi": "^9.0.0",
     "string-width": "^8.2.1",
     "strip-ansi": "^7.2.0",
     "supports-hyperlinks": "^4.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       micromark-util-combine-extensions:
         specifier: ^2.0.1
         version: 2.0.1
+      slice-ansi:
+        specifier: ^9.0.0
+        version: 9.0.0
       string-width:
         specifier: ^8.2.1
         version: 8.2.1
@@ -751,6 +754,10 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -844,6 +851,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1048,6 +1059,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1620,6 +1635,8 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -1709,6 +1726,10 @@ snapshots:
   has-flag@5.0.1: {}
 
   html-escaper@2.0.2: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2136,6 +2157,11 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -766,8 +766,51 @@ function renderTable(node: Table, ctx: RenderContext): string[] {
 
 function truncateCell(text: string, width: number, ellipsis: string): string {
   if (stringWidth(text) <= width) return text;
-  if (width <= ellipsis.length) return ellipsis.slice(0, width);
-  return text.slice(0, width - ellipsis.length) + ellipsis;
+  const ellipsisWidth = stringWidth(ellipsis);
+  if (width <= ellipsisWidth) return ellipsis.slice(0, width);
+
+  // Truncate by visible width while preserving ANSI escape sequences. Slicing
+  // by code units (the previous behavior) counted the invisible escape bytes
+  // toward the width and could cut mid-sequence, dropping the closing reset and
+  // leaking the style into the rest of the row. It also mismeasured wide (CJK)
+  // characters.
+  const budget = width - ellipsisWidth;
+  const chars = [...text];
+  let result = "";
+  let used = 0;
+  let hasAnsi = false;
+  for (let i = 0; i < chars.length; i++) {
+    const ch = chars[i];
+    if (ch === undefined) break;
+    if (ch.charCodeAt(0) === 0x1b) {
+      // Copy the whole CSI escape sequence (ESC [ … final-byte) without cost.
+      let seq = ch;
+      i++;
+      const intro = chars[i];
+      if (intro !== undefined) {
+        seq += intro;
+        i++;
+      }
+      while (i < chars.length) {
+        const c = chars[i];
+        if (c === undefined) break;
+        seq += c;
+        i++;
+        const code = c.charCodeAt(0);
+        if (code >= 0x40 && code <= 0x7e) break;
+      }
+      i--;
+      result += seq;
+      hasAnsi = true;
+      continue;
+    }
+    const chWidth = stringWidth(ch);
+    if (used + chWidth > budget) break;
+    result += ch;
+    used += chWidth;
+  }
+  // Close any style left open by the truncation so it cannot leak past the cell.
+  return `${result}${ellipsis}${hasAnsi ? "\u001b[0m" : ""}`;
 }
 
 function wrapCodeLine(text: string, width: number): string[] {

--- a/src/render.ts
+++ b/src/render.ts
@@ -9,6 +9,7 @@ import type {
   Root,
   Table,
 } from "mdast";
+import sliceAnsi from "slice-ansi";
 import stringWidth from "string-width";
 import stripAnsi from "strip-ansi";
 import { hyperlinkSupported, osc8 } from "./hyperlink.js";
@@ -767,50 +768,19 @@ function renderTable(node: Table, ctx: RenderContext): string[] {
 function truncateCell(text: string, width: number, ellipsis: string): string {
   if (stringWidth(text) <= width) return text;
   const ellipsisWidth = stringWidth(ellipsis);
-  if (width <= ellipsisWidth) return ellipsis.slice(0, width);
+  if (width <= ellipsisWidth) return sliceCellContent(ellipsis, width);
+  return `${sliceCellContent(text, width - ellipsisWidth)}${ellipsis}`;
+}
 
-  // Truncate by visible width while preserving ANSI escape sequences. Slicing
-  // by code units (the previous behavior) counted the invisible escape bytes
-  // toward the width and could cut mid-sequence, dropping the closing reset and
-  // leaking the style into the rest of the row. It also mismeasured wide (CJK)
-  // characters.
-  const budget = width - ellipsisWidth;
-  const chars = [...text];
-  let result = "";
-  let used = 0;
-  let hasAnsi = false;
-  for (let i = 0; i < chars.length; i++) {
-    const ch = chars[i];
-    if (ch === undefined) break;
-    if (ch.charCodeAt(0) === 0x1b) {
-      // Copy the whole CSI escape sequence (ESC [ … final-byte) without cost.
-      let seq = ch;
-      i++;
-      const intro = chars[i];
-      if (intro !== undefined) {
-        seq += intro;
-        i++;
-      }
-      while (i < chars.length) {
-        const c = chars[i];
-        if (c === undefined) break;
-        seq += c;
-        i++;
-        const code = c.charCodeAt(0);
-        if (code >= 0x40 && code <= 0x7e) break;
-      }
-      i--;
-      result += seq;
-      hasAnsi = true;
-      continue;
-    }
-    const chWidth = stringWidth(ch);
-    if (used + chWidth > budget) break;
-    result += ch;
-    used += chWidth;
+function sliceCellContent(text: string, width: number): string {
+  let end = Math.max(0, width);
+  let sliced = sliceAnsi(text, 0, end);
+  // slice-ansi owns ANSI/OSC/grapheme boundaries; clamp with Markdansi's width metric.
+  while (end > 0 && stringWidth(sliced) > width) {
+    end -= 1;
+    sliced = sliceAnsi(text, 0, end);
   }
-  // Close any style left open by the truncation so it cannot leak past the cell.
-  return `${result}${ellipsis}${hasAnsi ? "\u001b[0m" : ""}`;
+  return sliced;
 }
 
 function wrapCodeLine(text: string, width: number): string[] {

--- a/test/tables.test.ts
+++ b/test/tables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { strip } from "../src/index.ts";
+import { render, strip } from "../src/index.ts";
 
 const noColor = { color: false, hyperlinks: false, wrap: true, width: 40 };
 
@@ -187,6 +187,19 @@ describe("tables", () => {
 `;
     const out = strip(md, { ...noColor, width: 18, wrap: true });
     expect(out).toContain("…");
+  });
+
+  it("closes ANSI styling when truncating a styled cell", () => {
+    const md = "| Col |\n|---|\n| *averylongemphasizedwordthatexceedscol* |\n";
+    const out = render(md, { color: true, hyperlinks: false, wrap: true, width: 30 });
+    const ITALIC_ON = "[3m";
+    const ITALIC_OFF = "[23m";
+    const RESET = "[0m";
+    const open = out.lastIndexOf(ITALIC_ON);
+    expect(open).toBeGreaterThanOrEqual(0);
+    // The italic opened in the truncated cell must be closed before output ends.
+    const closed = out.indexOf(ITALIC_OFF, open) !== -1 || out.indexOf(RESET, open) !== -1;
+    expect(closed).toBe(true);
   });
 
   it("keeps at least ellipsis when width extremely small", () => {

--- a/test/tables.test.ts
+++ b/test/tables.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, it } from "vitest";
+import stringWidth from "string-width";
+import stripAnsiCodes from "strip-ansi";
 import { render, strip } from "../src/index.ts";
 
 const noColor = { color: false, hyperlinks: false, wrap: true, width: 40 };
+const ESC = "\u001B";
+const BEL = "\u0007";
+const ST = `${ESC}\\`;
+const ITALIC_ON = `${ESC}[3m`;
+const ITALIC_OFF = `${ESC}[23m`;
+
+function expectLinesWithinWidth(output: string, width: number) {
+  for (const line of output.trimEnd().split("\n")) {
+    expect(stringWidth(line)).toBeLessThanOrEqual(width);
+  }
+}
+
+function lineContaining(output: string, text: string): string {
+  return output.split("\n").find((line) => line.includes(text)) ?? "";
+}
+
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
 
 describe("tables", () => {
   it("does not linkify underscores inside tables", () => {
@@ -192,14 +213,89 @@ describe("tables", () => {
   it("closes ANSI styling when truncating a styled cell", () => {
     const md = "| Col |\n|---|\n| *averylongemphasizedwordthatexceedscol* |\n";
     const out = render(md, { color: true, hyperlinks: false, wrap: true, width: 30 });
-    const ITALIC_ON = "[3m";
-    const ITALIC_OFF = "[23m";
-    const RESET = "[0m";
-    const open = out.lastIndexOf(ITALIC_ON);
+    const row = lineContaining(out, "avery");
+    const open = row.indexOf(ITALIC_ON);
     expect(open).toBeGreaterThanOrEqual(0);
-    // The italic opened in the truncated cell must be closed before output ends.
-    const closed = out.indexOf(ITALIC_OFF, open) !== -1 || out.indexOf(RESET, open) !== -1;
-    expect(closed).toBe(true);
+    expect(row.indexOf(ITALIC_OFF, open)).toBeGreaterThan(open);
+    expect(row).toContain("…");
+    expectLinesWithinWidth(out, 30);
+  });
+
+  it("preserves OSC-8 hyperlinks when truncating linked cells", () => {
+    const url = "https://example.com/docs/very-long-target";
+    const md = `| Link |\n|---|\n| [averylonglinklabelthatexceeds](${url}) |\n`;
+    const out = render(md, { color: true, hyperlinks: true, wrap: true, width: 24 });
+    const row = lineContaining(out, "avery");
+    const open = `${ESC}]8;;${url}${BEL}`;
+    const close = `${ESC}]8;;${BEL}`;
+    expect(occurrences(row, open)).toBe(1);
+    expect(occurrences(row, close)).toBe(1);
+    expect(row.indexOf(close)).toBeGreaterThan(row.indexOf(open));
+    expect(row).toContain("…");
+    expectLinesWithinWidth(out, 24);
+  });
+
+  it("preserves ST-terminated OSC-8 hyperlinks when truncating cells", () => {
+    const open = `${ESC}]8;;example-link${ST}`;
+    const close = `${ESC}]8;;${ST}`;
+    const md = `| Link |\n|---|\n| ${open}averylonglinklabelthatexceeds${close} |\n`;
+    const out = render(md, { color: true, hyperlinks: false, wrap: true, width: 24 });
+    const row = lineContaining(out, "avery");
+    expect(occurrences(row, open)).toBe(1);
+    expect(occurrences(row, close)).toBe(1);
+    expect(row.indexOf(close)).toBeGreaterThan(row.indexOf(open));
+    expect(row).toContain("…");
+    expectLinesWithinWidth(out, 24);
+  });
+
+  it("keeps CJK and emoji cells within visible table width", () => {
+    const cjk = strip("| Col |\n|---|\n| 漢字漢字漢字漢字漢字漢字漢字漢字 |\n", {
+      ...noColor,
+      width: 12,
+      tablePadding: 0,
+    });
+    expect(cjk).toContain("…");
+    expectLinesWithinWidth(cjk, 12);
+
+    const kana = strip("| Kana |\n|---|\n| カﾞカﾞカﾞカﾞ |\n", {
+      ...noColor,
+      width: 10,
+      tablePadding: 0,
+    });
+    expect(kana).toContain("…");
+    expectLinesWithinWidth(kana, 10);
+
+    const flag = "🇺🇸";
+    const emoji = strip(`| Emoji |\n|---|\n| ${flag.repeat(8)} done |\n`, {
+      ...noColor,
+      width: 12,
+      tablePadding: 0,
+    });
+    const row = lineContaining(emoji, "…");
+    const cell = (stripAnsiCodes(row).split("│")[1] ?? "").trim();
+    const beforeEllipsis = cell.split("…")[0] ?? "";
+    const regionalIndicators = [...beforeEllipsis].filter((char) => {
+      const codePoint = char.codePointAt(0) ?? 0;
+      return codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff;
+    }).length;
+    expect(beforeEllipsis).toContain(flag);
+    expect(regionalIndicators % 2).toBe(0);
+    expectLinesWithinWidth(emoji, 12);
+  });
+
+  it("balances nested styling inside OSC-8 links when truncating cells", () => {
+    const url = "https://example.com/nested";
+    const md = `| Link |\n|---|\n| [*averylongemphasizedlinklabelthatexceeds*](${url}) |\n`;
+    const out = render(md, { color: true, hyperlinks: true, wrap: true, width: 28 });
+    const row = lineContaining(out, "avery");
+    const openLink = `${ESC}]8;;${url}${BEL}`;
+    const closeLink = `${ESC}]8;;${BEL}`;
+    expect(occurrences(row, openLink)).toBe(1);
+    expect(occurrences(row, closeLink)).toBe(1);
+    expect(row).toContain(ITALIC_ON);
+    expect(row).toContain(ITALIC_OFF);
+    expect(row).toContain("…");
+    expectLinesWithinWidth(out, 28);
   });
 
   it("keeps at least ellipsis when width extremely small", () => {


### PR DESCRIPTION
## What

`truncateCell` measures cell width with `stringWidth` (ANSI- and wide-character-aware) but cuts the string with `text.slice(0, width - ellipsis.length)`, which indexes by UTF-16 code units.

When a table cell has styled inline content (emphasis, strong, inline code, links), `renderInline` has already wrapped it in ANSI escape sequences. Slicing by code units then:

1. counts the invisible escape bytes toward the truncation length, and
2. cuts at an arbitrary offset, dropping the trailing reset.

So the opening escape survives but its closing reset is chopped off, and the style leaks into the rest of the row. Wide (CJK) characters are also mismeasured, overflowing the column border.

## Reproduction

```
| Col |
|---|
| *averylongemphasizedwordthatexceedscol* |
```

rendered with `{ color: true, width: 30 }` produces a data row containing the italic opener `^[[3m` with no matching `^[[23m` (open = 1, close = 0). The dangling escape leaks italic into all following output.

## Fix

Walk the cell by codepoint: copy CSI escape sequences (`ESC [ … final-byte`) through without counting their width, and stop once the visible-width budget is spent. Append a reset after the ellipsis when any escape was emitted, so an open style can't leak past the cell. This also fixes the CJK overflow because the cut is now driven by visible width.

## Tests

Added a case in `test/tables.test.ts`: a styled cell that gets truncated must have its style closed (a reset or italic-off after the opener). It fails before the change and passes after. The existing truncation tests use `color: false`, which is why this slipped through. Full table suite green (14 passed); `oxfmt`, `oxlint`, and `tsgo` typecheck clean.

Found and fixed with the help of the Claude CLI.


## Real behavior proof

Rendering the styled table at `width: 30, color: true` and inspecting the raw data row, before and after this change (output copied from a local `tsx` run):

```
BEFORE (main)
  data row   : "│ [3maverylongemphasized…     │"
  italic open: 1   italic-close/reset: 0
  balanced   : false        <- [3m opened, never closed; style leaks past the cell

AFTER (this PR)
  data row   : "│ [3maverylongemphasizedword…[0m │"
  italic open: 1   italic-close/reset: 1
  balanced   : true
```

Before the change the italic opener survives but its reset is sliced off, so the style leaks into the rest of the row. After the change the cell closes its own styling. Note the after-row also fits more visible characters ("…word…") because the escape bytes no longer count toward the truncation width.
