### PR TITLE
Fix extended built-in CLI themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.3 - Unreleased
 
+- CLI: restore support for the `solarized`, `monochrome`, and `contrast` built-in themes.
+
 ## 0.3.2 (2026-07-01)
 
 - CLI: apply documented table/code rendering flags and reject invalid, missing, or unknown options with clear errors (#7).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install markdansi
 Quick one-shot renderer: pipe Markdown in, ANSI comes out. Flags let you pick width, wrap, colors, links, and table/list styling.
 
 ```bash
-markdansi [FILE] [--in FILE] [--out FILE] [--width N] [--no-wrap] [--no-color] [--no-links] [--theme default|dim|bright]
+markdansi [FILE] [--in FILE] [--out FILE] [--width N] [--no-wrap] [--no-color] [--no-links] [--theme default|dim|bright|solarized|monochrome|contrast]
 [--list-indent N] [--quote-prefix STR]
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -47,7 +47,7 @@ Each theme entry holds simple SGR intents (bold/italic/fg color names). `inlineC
 
 ### CLI
 
-`markdansi [FILE] [--in FILE] [--out FILE] [--width N] [--no-wrap] [--no-color] [--no-links] [--theme default|dim|bright]`
+`markdansi [FILE] [--in FILE] [--out FILE] [--width N] [--no-wrap] [--no-color] [--no-links] [--theme default|dim|bright|solarized|monochrome|contrast]`
 
 - Input: positional `FILE`, `--in FILE`, or stdin when neither is given.
 - Output: stdout if no `--out`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { render } from "./index.js";
+import { themeNames } from "./types.js";
 import type { RenderOptions, ThemeName } from "./types.js";
 
 type CliArgs = Partial<RenderOptions> & {
@@ -34,8 +35,9 @@ function parseIntegerOption(option: string, value: string, minimum: number): num
 }
 
 function parseTheme(value: string): ThemeName {
-  if (value === "default" || value === "dim" || value === "bright") return value;
-  throw new Error("--theme must be default, dim, or bright");
+  const theme = themeNames.find((candidate) => candidate === value);
+  if (theme) return theme;
+  throw new Error(`--theme must be one of: ${themeNames.join(", ")}`);
 }
 
 function parseTableBorder(value: string): NonNullable<RenderOptions["tableBorder"]> {
@@ -144,7 +146,7 @@ Options:
   --no-wrap           Disable hard wrapping
   --no-color          Disable ANSI/OSC output
   --no-links          Disable OSC-8 hyperlinks
-  --theme NAME        Theme (default|dim|bright)
+  --theme NAME        Theme (${themeNames.join("|")})
   --list-indent N     Spaces per list nesting level (default: 2)
   --quote-prefix STR  Prefix for blockquotes (default: "│ ")
   --table-border STR  unicode|ascii|none

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,6 @@
 import type { ChalkInstance } from "chalk";
 import { Chalk } from "chalk";
-import type { StyleIntent, Theme } from "./types.js";
+import type { StyleIntent, Theme, ThemeName } from "./types.js";
 
 const base: Theme = {
   heading: { color: "yellow", bold: true },
@@ -70,15 +70,7 @@ const contrast: Theme = {
   tableCell: { color: "white" },
 };
 
-export interface Themes {
-  default: Theme;
-  dim: Theme;
-  bright: Theme;
-  solarized: Theme;
-  monochrome: Theme;
-  contrast: Theme;
-  [key: string]: Theme;
-}
+export type Themes = Record<ThemeName, Theme> & Record<string, Theme>;
 
 export const themes: Themes = {
   default: Object.freeze(base),

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,16 @@ export type Theme = {
   tableCell?: StyleIntent;
 };
 
-export type ThemeName = "default" | "dim" | "bright";
+export const themeNames = [
+  "default",
+  "dim",
+  "bright",
+  "solarized",
+  "monochrome",
+  "contrast",
+] as const;
+
+export type ThemeName = (typeof themeNames)[number];
 
 export type Highlighter = (code: string, lang?: string) => string;
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -33,10 +33,17 @@ describe("cli input args", () => {
     );
   });
 
-  it("accepts documented separate theme and table border values", () => {
-    expect(
-      parseArgs(["node", "cli", "--theme", "bright", "--table-border", "ascii"]),
-    ).toMatchObject({ theme: "bright", tableBorder: "ascii" });
+  it.each(["default", "dim", "bright", "solarized", "monochrome", "contrast"])(
+    "accepts the built-in %s theme",
+    (theme) => {
+      expect(parseArgs(["node", "cli", "--theme", theme])).toMatchObject({ theme });
+    },
+  );
+
+  it("accepts a documented separate table border value", () => {
+    expect(parseArgs(["node", "cli", "--table-border", "ascii"])).toMatchObject({
+      tableBorder: "ascii",
+    });
   });
 
   it("accepts dash-prefixed text values and bare code flags", () => {
@@ -68,7 +75,10 @@ describe("cli input args", () => {
     [["--list-indent", ""], "--list-indent must be a non-negative integer"],
     [["--list-indent", "-1"], "--list-indent must be a non-negative integer"],
     [["--table-padding", "1.5"], "--table-padding must be a non-negative integer"],
-    [["--theme", "neon"], "--theme must be default, dim, or bright"],
+    [
+      ["--theme", "neon"],
+      "--theme must be one of: default, dim, bright, solarized, monochrome, contrast",
+    ],
     [["--table-border", "rounded"], "--table-border must be unicode, ascii, or none"],
     [["--width"], "--width requires a value"],
     [["--wat"], "unknown option: --wat"],
@@ -115,6 +125,18 @@ describe("cli input args", () => {
     expect(output).toContain("+----+----+");
     expect(output).not.toContain("┌");
     expect(output).toContain("const x = 1;");
+  });
+
+  it("renders with an extended built-in theme", () => {
+    const result = spawnSync(
+      "pnpm",
+      ["exec", "tsx", "src/cli.ts", "--theme", "solarized", "--no-color", "--no-links"],
+      { encoding: "utf8", input: "# Solarized\n" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Solarized");
   });
 
   it("reports invalid numeric options without a stack trace", () => {


### PR DESCRIPTION
## Summary

- restore CLI support for all six built-in themes
- derive parser validation and help text from one canonical theme-name list
- preserve the public string-indexable theme registry type
- align README, spec, changelog, and regression coverage

## Root cause

PR #7 added strict CLI theme validation using the stale three-value `ThemeName` union. The renderer has included `solarized`, `monochrome`, and `contrast` since `48888e9`, and the previous CLI forwarded those names at runtime. The resulting `0.3.2` package rejected valid built-in names.

Closes the unresolved review finding from https://github.com/steipete/Markdansi/pull/7#discussion_r3504539476.

## Verification

- `pnpm exec vitest run test/cli.test.ts` — 25 tests
- `pnpm build` — format, lint, typecheck, 105 tests, compile
- `pnpm types`
- source-blind built CLI: all six names exit 0; TTY rendering produces six distinct output hashes; help lists the same set; unknown theme exits 1
- `pnpm audit --json` — zero vulnerabilities
- `pnpm outdated --format json` — no direct updates
- `npm pack --dry-run --json` — 25 package files
- `autoreview --mode local` — clean after preserving the public dynamic-string registry type

## Risk

Low. The change restores shipped behavior and expands a stale public type union to match existing runtime themes. No dependency or renderer algorithm changes.
