### PR TITLE
Fix custom theme color application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.3 - Unreleased
 
+- Themes: apply named, hex, and ANSI-256 foreground/background colors, fixing Solarized block code styling.
 - CLI: restore support for the `solarized`, `monochrome`, and `contrast` built-in themes.
 
 ## 0.3.2 (2026-07-01)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -41,7 +41,7 @@ Dev: `vitest`, TypeScript (NodeNext).
 `}``
 
 `type Theme = { heading, strong, emph, inlineCode, blockCode, code?, link, quote, hr, listMarker, tableHeader, tableCell, tableBorder, tableSeparator }`
-Each theme entry holds simple SGR intents (bold/italic/fg color names). `inlineCode` / `blockCode` are used if present; otherwise `code` acts as a fallback for both. Theme exposes defaults for table borders/separators; caller can override per render via options above.
+Each theme entry holds simple SGR intents (bold/italic plus named, `#rrggbb`, or ANSI-256 numeric-string foreground/background colors). `inlineCode` / `blockCode` are used if present; otherwise `code` acts as a fallback for both. Theme exposes defaults for table borders/separators; caller can override per render via options above.
 
 `strip(markdown: string): string` — convenience: render with `color=false`, `hyperlinks=false`.
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,6 @@
 import type { ChalkInstance } from "chalk";
 import { Chalk } from "chalk";
-import type { StyleIntent, Theme, ThemeName } from "./types.js";
+import type { ColorName, StyleIntent, Theme, ThemeName } from "./types.js";
 
 const base: Theme = {
   heading: { color: "yellow", bold: true },
@@ -83,6 +83,21 @@ export const themes: Themes = {
 
 export type Styler = (text: string, style?: StyleIntent) => string;
 
+function applyColor(fn: ChalkInstance, color: ColorName, background = false): ChalkInstance {
+  if (color.startsWith("#")) return background ? fn.bgHex(color) : fn.hex(color);
+
+  if (/^\d+$/.test(color)) {
+    const index = Number(color);
+    if (index <= 255) return background ? fn.bgAnsi256(index) : fn.ansi256(index);
+    return fn;
+  }
+
+  const name =
+    background && !color.startsWith("bg") ? `bg${color[0]?.toUpperCase()}${color.slice(1)}` : color;
+  const indexed = fn as unknown as Record<string, ChalkInstance | undefined>;
+  return indexed[name] ?? fn;
+}
+
 /**
  * Create a Chalk-based styling helper that applies StyleIntent safely.
  */
@@ -92,14 +107,8 @@ export function createStyler({ color }: { color: boolean }): Styler {
   const apply: Styler = (text, style = {}) => {
     if (!color) return text;
     let fn: ChalkInstance = chalk;
-    if (style.color) {
-      const indexed = fn as unknown as Record<string, ChalkInstance | undefined>;
-      if (indexed[style.color]) fn = indexed[style.color] as ChalkInstance;
-    }
-    if (style.bgColor) {
-      const indexed = fn as unknown as Record<string, ChalkInstance | undefined>;
-      if (indexed[style.bgColor]) fn = indexed[style.bgColor] as ChalkInstance;
-    }
+    if (style.color) fn = applyColor(fn, style.color);
+    if (style.bgColor) fn = applyColor(fn, style.bgColor, true);
     if (style.bold) fn = fn.bold;
     if (style.italic) fn = fn.italic;
     if (style.underline) fn = fn.underline;

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -245,6 +245,27 @@ describe("styling helpers", () => {
     expect(styled).toContain("\u001b[9m"); // strike
   });
 
+  it("applies named, hex, and ANSI-256 foreground and background colors", () => {
+    const style = createStyler({ color: true });
+
+    expect(style("x", { color: "#2aa198" })).toContain("\u001b[38;2;42;161;152m");
+    expect(style("x", { bgColor: "#2aa198" })).toContain("\u001b[48;2;42;161;152m");
+    expect(style("x", { color: "42" })).toContain("\u001b[38;5;42m");
+    expect(style("x", { bgColor: "42" })).toContain("\u001b[48;5;42m");
+    expect(style("x", { bgColor: "blue" })).toContain("\u001b[44m");
+  });
+
+  it("applies the Solarized block-code color", () => {
+    const ansi = render("```\nblock\n```", {
+      color: true,
+      theme: "solarized",
+      wrap: false,
+      codeBox: false,
+    });
+
+    expect(ansi).toContain("\u001b[38;2;42;161;152m");
+  });
+
   it("uses default theme colors (cyan inline, green block, yellow header)", () => {
     const ansi = render("`inline`\n\n```\nblock\n```\n\n# H", {
       color: true,


### PR DESCRIPTION
## Summary

- apply the public named, hex, and ANSI-256 color forms to foregrounds and backgrounds
- restore Solarized fenced-code truecolor output
- preserve existing dynamic named-background behavior
- document the color contract and add focused regression coverage

## Root cause

The theme type has long allowed hex and numeric color strings, and the built-in Solarized theme uses a hex block-code color. The styler only looked up Chalk's named properties, so those declared values were silently ignored. This surfaced while closing out https://github.com/steipete/Markdansi/pull/8.

## Verification

- `pnpm build` — formatting, lint, typecheck, 107 tests, compile
- `pnpm types`
- `pnpm audit --json` — zero vulnerabilities
- packed-artifact source-blind validation — Solarized CLI emitted RGB 42/161/152 in a TTY; ESM consumer emitted expected hex and ANSI-256 foreground/background sequences; named backgrounds remained functional; varied RGB changed output; color-off emitted no escape sequences
- `autoreview --mode local` — clean; no accepted/actionable findings

## Risk

Low. Change is isolated to style-intent color dispatch, preserves named-color fallbacks, and adds exact ANSI-sequence regression coverage.
