### PR TITLE
chore(release): prepare 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.3 - Unreleased
+## 0.3.3 (2026-08-02)
 
 - Dependencies: update Chalk 6, Marked, string-width, and build tooling, including current PostCSS security fixes.
 - Themes: apply named, hex, and ANSI-256 foreground/background colors, fixing Solarized block code styling.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdansi",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Tiny dependency-light markdown to ANSI converter.",
   "keywords": [
     "ansi",


### PR DESCRIPTION
## Summary

- set the package version to 0.3.3
- close the 0.3.3 changelog section with the authorized 2026-08-02 release date

## Release gate

- queue is zero
- Node 22.13 frozen install and full build pass
- 109 tests pass; declarations compile
- built CLI smoke prints `Release 0.3.3`
- `npm publish --dry-run` produces `markdansi-0.3.3.tgz`
- autoreview clean with no accepted/actionable findings
