### PR TITLE
chore: reopen development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.3.4 - Unreleased
+
 ## 0.3.3 (2026-08-02)
 
 - Dependencies: update Chalk 6, Marked, string-width, and build tooling, including current PostCSS security fixes.


### PR DESCRIPTION
## Summary

- reopen the changelog with an empty 0.3.4 Unreleased section after the verified 0.3.3 release

## Proof

- `pnpm format:check` passes
- autoreview clean with no accepted/actionable findings
